### PR TITLE
Clarify request binding for DID authentication proofs

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -182,6 +182,10 @@
           <li>Construct the Authorization header in the above format and send it to the service.</li>
         </ol>
 
+        <h5>Request Binding</h5>
+        <p>The authentication proof should be bound to the HTTP request that it authorizes, not only to the client's DID, nonce, timestamp, and service domain. The signed input should cover the HTTP method, authority, path with query or equivalent target URI, creation timestamp, nonce, verification method, and, for requests with bodies, a digest of the request content.</p>
+        <p>Future revisions can define this request-bound proof using an explicit canonical request object or by profiling <a href="https://www.rfc-editor.org/rfc/rfc9421.html">RFC 9421 HTTP Message Signatures</a> together with <a href="https://www.rfc-editor.org/rfc/rfc9530.html">RFC 9530 HTTP Digest Fields</a>. Whichever syntax is chosen, verifiers should reconstruct the covered request components from the received request before accepting the signature.</p>
+
         <h4>Service Verification</h4>
         <h5>Verify Request Header</h5>
         <p>After receiving the client's request, the service performs the following verification:</p>


### PR DESCRIPTION
## Summary

This adds a narrow request-binding clarification to the current `did:wba` first-request authentication section.

The text clarifies that:

- DID authentication proofs should bind to the HTTP request they authorize
- identity and freshness fields alone are not sufficient
- signed input should cover method, authority, path/query or equivalent target URI, creation time, nonce, verification method, and request body digest when a body is present
- future revisions can express the profile through an explicit canonical request object or RFC 9421 + RFC 9530

## Motivation

This is motivated by implementation work in JACS and discussion in #28. The change intentionally avoids a full authentication rewrite while the group explores an RFC 9421 / RFC 9530 based scheme.

Closes #28.

## Validation

- Parsed `protocol.html` with Python's standard `html.parser`
- Ran `git diff --check`
- Reviewed diff for vendor-neutral language and no JACS-specific identifiers
