### PR TITLE
Add key continuity guidance for did:wba key rotation

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -421,6 +421,16 @@ did:wba:example.com%3A3000:user:alice:e1_&lt;fingerprint&gt;
 </ol>
 </blockquote>
 </section>
+<section id="did-wba-key-continuity">
+<h5>Key Continuity</h5>
+<p>Agents frequently exist in systems that already manage signing keys and identifiers. This section describes how such a system presents a stable DID while keys rotate underneath it, and how relying parties can follow a rotation. It applies to DIDs whose identifier does not bind a specific key: naked domain name DIDs and historical path-type DIDs without an <code>e1_</code> fingerprint segment. For <code>e1_</code> path-type DIDs, a binding key change necessarily produces a new DID as defined in the Update section; the transition statement below can also link the old and new DIDs during such a migration.</p>
+<ol>
+<li><strong>DID stability.</strong> A DID SHOULD remain stable across routine key rotation. Rotation is expressed by updating the DID document's <code>verificationMethod</code> entries and the references in <code>authentication</code> and <code>assertionMethod</code>, not by minting a new DID.</li>
+<li><strong>Key-identifying fragments.</strong> Verification method ids SHOULD identify concrete keys, for example by RFC 7638 JWK thumbprint: <code>did:wba:example.com:user:alice#&lt;thumbprint&gt;</code>. This gives implementations a stable place to attach key versions without destabilizing the DID itself, and reuses the same thumbprint construction this specification already relies on for <code>e1_</code> binding.</li>
+<li><strong>Key continuity attestation (optional).</strong> On rotation, the previous key MAY sign a transition statement covering the DID (or the old and new DIDs, when the identifier changes), the previous key thumbprint, the new key thumbprint, and a timestamp. A relying party that pinned the previous key can then accept the new key without out-of-band re-verification. If no attestation is available, verifiers fall back to normal DID resolution and their own trust policy. A transition statement is evidence of continuity, not proof of non-compromise; verifiers MAY still apply revocation or freshness policies.</li>
+<li><strong>System-native identifiers.</strong> Identifiers and version markers native to the underlying system SHOULD remain in system metadata rather than being encoded into the DID. Keeping them out of the DID is what keeps the DID stable across rotation and system-internal versioning.</li>
+</ol>
+</section>
 <section id="did-wba-deactivation">
 <h5>Deactivation</h5>
 <p>To delete a DID document, the <code>did.json</code> file must be removed or otherwise no longer publicly available.</p>


### PR DESCRIPTION
Follow-up to the proposal in #27 ([comment](https://github.com/w3c-cg/ai-agent-protocol/issues/27#issuecomment-4861359321)), where @chgaowei asked for a concrete implementation proposal. This adds a short **Key Continuity** subsection to the did:wba method operations, between Update and Deactivation.

What it covers:

- **DID stability across routine rotation** for DIDs whose identifier does not bind a key (naked domain name DIDs and historical path DIDs): rotation updates `verificationMethod` entries, it does not mint a new DID.
- **Key-identifying fragments** via RFC 7638 JWK thumbprints — the same construction this spec already uses for `e1_` binding, so it should feel familiar.
- **An optional key-continuity attestation**: the previous key signs a transition statement (previous/new thumbprints + timestamp), so a relying party that pinned the old key can follow a rotation without out-of-band re-verification. For `e1_` DIDs, where a binding-key change necessarily produces a new DID, the same statement can link the old and new DIDs during migration — complementing the Agent Name Service handoff the Update section describes.
- **Keeping system-native identifiers in system metadata** rather than encoding them into the DID.

A few notes:

- The earlier point in #27 about verification method types is already addressed — the current draft uses `Multikey`, so this PR doesn't touch key representation.
- Text is deliberately SHOULD/MAY; happy to adjust strength to whatever the group prefers.
- Scoped separately from #39 (request binding) so each can be reviewed on its own; together they cover "which key, across time" and "what this key authorized".
- We generated validation material from a running implementation: before/after DID documents from a real rotation (same DID, updated verification method) plus a signed transition statement. I'll link the fixtures in a comment, and I'm happy to commit them into the repo instead if in-tree validation material is preferred.

Closes #27, if the group agrees this addresses it.
